### PR TITLE
버튼 관련 문제 수정

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -58,7 +58,8 @@
 .section:not(.fake) {
     position: relative;
     z-index: -4;
-    padding-left: 10em;
+    /* #menu left : 1em + width : 10em = 11em */
+    padding-left: 11em;
     background: white;
     background-clip: padding-box;
 }
@@ -107,6 +108,7 @@ button.btn-learn-more::after {
 }
 button.btn-learn-more > span {
     opacity: 0;
+    visibility: hidden;
     transition: all 300ms ease 0ms;
     color: black;
     margin: auto;
@@ -114,6 +116,7 @@ button.btn-learn-more > span {
 }
 button.btn-learn-more:hover > span {
     opacity: 1;
+    visibility: visible;
     transition-delay: 150ms;
 }
 button.btn-learn-more > i {

--- a/css/main.css
+++ b/css/main.css
@@ -58,7 +58,7 @@
 .section:not(.fake) {
     position: relative;
     z-index: -4;
-    /* #menu left : 1em + width : 10em = 11em */
+    /* #menu left + width = 1em + 10em = 11em */
     padding-left: 11em;
     background: white;
     background-clip: padding-box;


### PR DESCRIPTION
#3 이슈에 대한 수정입니다.

1. >에 닿지 않고 흰색 부분에만 닿는 경우 버튼이 펼쳐지지 않음.
- menu 의 left + width 는 11em 이지만, section 의 padding-left 는 10em 이므로 1em 의 차이가 발생하여 나는 문제입니다.
- 해당 문제는 11em 으로 padding-left 하여 수정하였습니다.
2. 펼쳐진 상태의 버튼이 있을 오른쪽 부분에 마우스를 가져다 되면 버튼이 펼쳐짐.
- 해당 문제는 span (텍스트) 의 영역이 width 가 0임에도 불구하고 남아있는 문제였습니다.
- visibility 로 해당 영역을 아예 숨김 처리 하여 처리하였습니다.